### PR TITLE
create SSOT for setup and install requires common

### DIFF
--- a/rcli/autodetect.py
+++ b/rcli/autodetect.py
@@ -70,9 +70,9 @@ def egg_info_writer(cmd, basename, filename):
     config = dict(parser.items('rcli'))
     for k, v in six.iteritems(config):
         if v.lower() in ('y', 'yes', 'true'):
-            config[k] = True
+            config[k] = True  # type: ignore
         elif v.lower() in ('n', 'no', 'false'):
-            config[k] = False
+            config[k] = False  # type: ignore
         else:
             try:
                 config[k] = json.loads(v)

--- a/rcli/config.py
+++ b/rcli/config.py
@@ -21,7 +21,7 @@ import sys
 import types
 import typing
 
-from typingplus.types import Singleton
+from typet import Singleton
 import pkg_resources
 import setuptools  # noqa: F401 pylint: disable=unused-import
 import six
@@ -104,6 +104,7 @@ class _RcliConfig(object):
         """The distribution containing the currently active entry point."""
         if self.entry_point:
             return self.entry_point.dist
+        return None
 
     def __getattr__(self, attr):
         # type: (str) -> typing.Any

--- a/rcli/dispatcher.py
+++ b/rcli/dispatcher.py
@@ -11,11 +11,12 @@ from __future__ import unicode_literals
 import logging
 import sys
 import types  # noqa: F401 pylint: disable=unused-import
-import typing  # noqa: F401 pylint: disable=unused-import
+
 
 from docopt import docopt
 import colorama
 import six
+import typingplus as typing
 
 from . import (  # noqa: F401 pylint: disable=unused-import
     exceptions as exc,
@@ -26,6 +27,7 @@ from . import (  # noqa: F401 pylint: disable=unused-import
 )
 from .config import settings
 
+typing.upgrade_typing()
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/rcli/display.py
+++ b/rcli/display.py
@@ -106,7 +106,7 @@ def display_status():
             raise e.exc  # pylint: disable=raising-bad-type
     except (KeyboardInterrupt, EOFError):
         raise
-    except:
+    except Exception:
         print_status('FAILED', Fore.RED)
         raise
     else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,6 @@ warn_no_return = False
 ignore_errors = True
 
 [pylint]
-disable = ungrouped-imports,no-name-in-module,too-few-public-methods,invalid-sequence-index,bad-continuation,import-error,invalid-name,no-member,locally-disabled,locally-enabled,redefined-outer-name,redefined-variable-type
+disable = ungrouped-imports,no-name-in-module,too-few-public-methods,invalid-sequence-index,bad-continuation,import-error,invalid-name,no-member,locally-disabled,locally-enabled,redefined-outer-name,redefined-variable-type,stop-iteration-return
 reports = no
 known-standard-library = typing

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,14 @@ from setuptools import find_packages
 if os.path.isdir('rcli.egg-info'):
     try:
         shutil.rmtree('rcli.egg-info')
-    except:  # pylint: disable=bare-except
+    except IOError:
         pass
 
 with open('README.rst') as readme_fp:
     readme = readme_fp.read()
 
+common_requires = ['docopt >= 0.6.2, < 1',
+                   'six >= 1.10.0']
 setup(
     name='rcli',
     use_scm_version=True,
@@ -32,22 +34,17 @@ setup(
     license='MIT',
     packages=find_packages(exclude=['tests', 'docs']),
     install_requires=[
-        'typingplus >= 1.0.2, < 2',
+        'typet >= 0.3.5, < 4',
         'backports.shutil_get_terminal_size',
         'colorama >= 0.3.6, < 1',
-        'tqdm >= 4.9.0, < 5',
-        'docopt >= 0.6.2, < 1',
-        'six >= 1.10.0'
-    ],
+        'tqdm >= 4.9.0, < 5'
+    ] + common_requires,
     setup_requires=[
-        'six >= 1.10.0',
         'packaging',
         'appdirs',
         'pytest-runner',
-        'setuptools_scm',
-        'typingplus >= 1.0.2, < 2',
-        'docopt >= 0.6.2, < 1'
-    ],
+        'setuptools_scm'
+    ] + common_requires,
     tests_require=[
         'pytest >= 3.0'
     ],

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -72,6 +72,7 @@ def test_py2_annotations(create_project, run):
     """Test type hinting with Python 2 annotations."""
     with create_project('''
         def types(str1, num):
+            # type: (str, int) -> None
             """usage: say types <str1> <num>"""
             print(type(str1))
             print(type(num))


### PR DESCRIPTION
Problem: Some pacakages are required both for setup
and install.  At least in the cases covered thus far
a single version should be available for both processes.

Analysis: Added "common_requires" list to store common
requirements.

Tests: Manual pip install and freeze

NOTE:  Also made flake8 and pep257 pass for seutp.py