### PR TITLE
support working with ini-style setup.py entry_points

### DIFF
--- a/rcli/autodetect.py
+++ b/rcli/autodetect.py
@@ -40,14 +40,7 @@ def setup_keyword(dist, _, value):
     """
     if value is not True:
         return
-    if dist.entry_points is None:
-        dist.entry_points = {}
-    elif isinstance(dist.entry_points, str):
-        config = configparser.ConfigParser()
-        config.read_string(dist.entry_points)
-        dist.entry_points = {k: ['='.join(t) for t in v]
-                             for k, v in config.items()
-                             if k != config.default_section}
+    dist.entry_points = _ensure_entry_points_is_dict(dist.entry_points)
 
     for command, subcommands in six.iteritems(_get_commands(dist)):
         entry_point = '{command} = rcli.dispatcher:main'.format(
@@ -56,6 +49,18 @@ def setup_keyword(dist, _, value):
         if entry_point not in entry_points:
             entry_points.append(entry_point)
         dist.entry_points.setdefault('rcli', []).extend(subcommands)
+
+
+def _ensure_entry_points_is_dict(entry_points):
+    if not entry_points:
+        return {}
+    elif isinstance(entry_points, str):
+        config = configparser.ConfigParser()
+        config.read_string(entry_points)
+        return {k: ['='.join(t) for t in section.items()]
+                for k, section in config.items()
+                if k != config.default_section}
+    return entry_points
 
 
 def egg_info_writer(cmd, basename, filename):

--- a/rcli/autodetect.py
+++ b/rcli/autodetect.py
@@ -12,6 +12,7 @@ from __future__ import unicode_literals
 
 import ast
 import collections
+import configparser
 import json
 import os.path
 import typing
@@ -41,6 +42,13 @@ def setup_keyword(dist, _, value):
         return
     if dist.entry_points is None:
         dist.entry_points = {}
+    elif isinstance(dist.entry_points, str):
+        config = configparser.ConfigParser()
+        config.read_string(dist.entry_points)
+        dist.entry_points = {k: ['='.join(t) for t in v]
+                             for k, v in config.items()
+                             if k != config.default_section}
+
     for command, subcommands in six.iteritems(_get_commands(dist)):
         entry_point = '{command} = rcli.dispatcher:main'.format(
             command=command)

--- a/tests/test_autodetect.py
+++ b/tests/test_autodetect.py
@@ -1,0 +1,21 @@
+from rcli.autodetect import _ensure_entry_points_is_dict
+
+
+def test_ensure_entry_points_is_dict_works_with_none():
+    assert _ensure_entry_points_is_dict(None) == {}
+
+
+def test_ensure_entry_points_is_dict_works_with_dict():
+    expected = {
+        'console_scripts': ['foobarbaz=foo.bar:baz'],
+    }
+    assert _ensure_entry_points_is_dict(expected) == expected
+
+
+def test_ensure_entry_points_is_dict_works_with_str():
+    assert _ensure_entry_points_is_dict('''
+    [console_scripts]
+    foobarbaz=foo.bar:baz
+    ''') == {
+        'console_scripts': ['foobarbaz=foo.bar:baz'],
+    }


### PR DESCRIPTION
relevant section from the [setuptools docs](https://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins):

> The entry_points argument to setup() accepts either a string with .ini-style sections, or a dictionary mapping entry point group names to either strings or lists of strings containing entry point specifiers. An entry point specifier consists of a name and value, separated by an = sign.
